### PR TITLE
Support get serail configure values from FW

### DIFF
--- a/drivers/s8250mem32/s8250mem32.c
+++ b/drivers/s8250mem32/s8250mem32.c
@@ -32,9 +32,14 @@
 #include <kconfig.h>
 #include <libpayload-config.h>
 #include <libpayload.h>
-
+#include <ewarg.h>
+#include <ewlog.h>
 #include <hwconfig.h>
 #include "s8250mem32.h"
+
+#define SBL_SERIAL_BASEADDR "serail_baseaddr"
+#define SBL_SERIAL_TYPE "serail_type"
+#define SBL_SERIAL_REGWIDTH "serail_regwidth"
 
 #ifndef SERIAL_BASEADDR
 #include <pci/pci.h>
@@ -55,10 +60,28 @@ static uint32_t GetPciUartBase(uint32_t pci_did)
 static EFI_STATUS s8250mem32_init(__attribute__((__unused__)) EFI_SYSTEM_TABLE *st)
 {
 	static struct cb_serial s;
+	const char *val;
 
-	s.baseaddr = SERIAL_BASEADDR;
-	s.regwidth = HW_SERIAL_REG_WIDTH;
-	s.type = HW_SERIAL_TYPE;
+	val = ewarg_getval(SBL_SERIAL_BASEADDR);
+	if (val) {
+		s.baseaddr = (UINT32)strtoull(val, NULL, 16);
+	} else {
+		s.baseaddr = SERIAL_BASEADDR;
+	}
+
+	val = ewarg_getval(SBL_SERIAL_TYPE);
+	if (val) {
+		s.type = (UINT32)strtoull(val, NULL, 16);
+	} else {
+		s.type = HW_SERIAL_TYPE;
+	}
+
+	val = ewarg_getval(SBL_SERIAL_REGWIDTH);
+	if (val) {
+		s.regwidth = (UINT32)strtoull(val, NULL, 16);
+	} else {
+		s.regwidth = HW_SERIAL_REG_WIDTH;
+	}
 
 	lib_sysinfo.serial = &s;
 

--- a/include/hardware/hw_alderlake.h
+++ b/include/hardware/hw_alderlake.h
@@ -27,37 +27,20 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __HW_TIGERLAKE__
-#define __HW_TIGERLAKE__
+#ifndef __HW_ALDERLAKE__
+#define __HW_ALDERLAKE__
 
 /* PCI device id of OTG */
 #define XDCI_PID         0x9D30
 #define XHCI_PID         0x9D2F
-
-/* PCI device id of EMMC controller */
-#define EMMC_DEVICEID    0xA0C4
-
-/* UFS */
-#define UFS_PCI_DID    0xA0FA
-
 /* NVME */
 #define NVME_PCI_DID    0xA80A
 #define NVME_DISKBUS    0x0000 //bbddff
 
 /* serial port base address */
-#if 0
-#define SERIAL_BASEADDR       0x2008
-#define SERIAL_PCI_DID        0x9922
-#define HW_SERIAL_TYPE        CB_SERIAL_TYPE_IO_MAPPED
-#define HW_SERIAL_REG_WIDTH   1
-#else
-#define SERIAL_BASEADDR 0x82404000
+#define SERIAL_BASEADDR     0x824D1000
 #define HW_SERIAL_REG_WIDTH 4
-#define HW_SERIAL_TYPE 2
-#endif
+#define HW_SERIAL_TYPE      2
 
-/* TCO base address, to be determined */
-#define TCOBASE    (0xffffffff)
-
-#endif /* __HW_TIGERLAKE__ */
+#endif /* __HW_ALDERLAKE__ */
 


### PR DESCRIPTION
SBL inits the serail and passes the base address to kernelflinger

Tracked-On: OAM-110927