### PR TITLE
kernelflinger: efiwrapper: find rsdp in ebda area

### DIFF
--- a/drivers/acpi/acpi.c
+++ b/drivers/acpi/acpi.c
@@ -98,11 +98,21 @@ static uint8_t checksum(uint8_t *buf, size_t size)
 static struct RSDP_TABLE *lookup_for_rdsp(char *from)
 {
 	char *p;
+	/*
+	 * The  0x40e stores EBDA segment address, need left shift 4 bits
+	 * to get EBDA physical address.
+	 */
+	uint16_t *ebda_seg_addr = (uint16_t *)0x40e;
 
 	if (!from)
 		from = (char *)0xE0000;
 
 	for (p = from; p < (char *)0x100000; p += 16)
+		if (!memcmp(p, RSDP_MAGIC, sizeof(RSDP_MAGIC)))
+			return (struct RSDP_TABLE *)p;
+
+	from = (char *)((*ebda_seg_addr) << 4);
+	for (p = from; p < (from + 0x400); p += 16)
 		if (!memcmp(p, RSDP_MAGIC, sizeof(RSDP_MAGIC)))
 			return (struct RSDP_TABLE *)p;
 


### PR DESCRIPTION
Per ACPI spec (5.2.5.1 Finding the RSDP on IA-PC Systems), OSPM could find RSDP by searching physical memory ranges on 16-byte boundaries at "The first 1 KB of
 the Extended BIOS Data Area (EBDA). For EISA or MCA systems, the EBDA can
be found in the two-byte location 40:0Eh on the BIOS data area."

Although EBDA is deprecated on modern UEFI platform, but it could exist on some virtualization platfroms. Since ACPI RSDP info is not supported by multiboot protocol so it might get lost by searching 0xe0000~0x100000 area only.