### PR TITLE
Fix typo in parsing serial config arguments

### DIFF
--- a/drivers/s8250mem32/s8250mem32.c
+++ b/drivers/s8250mem32/s8250mem32.c
@@ -37,9 +37,9 @@
 #include <hwconfig.h>
 #include "s8250mem32.h"
 
-#define SBL_SERIAL_BASEADDR "serail_baseaddr"
-#define SBL_SERIAL_TYPE "serail_type"
-#define SBL_SERIAL_REGWIDTH "serail_regwidth"
+#define SBL_SERIAL_BASEADDR "serial_baseaddr"
+#define SBL_SERIAL_TYPE "serial_type"
+#define SBL_SERIAL_REGWIDTH "serial_regwidth"
 
 #ifndef SERIAL_BASEADDR
 #include <pci/pci.h>


### PR DESCRIPTION
"serail" should be "serial".

Fixes: 4df084be1de1 ("Support get serail configure values from FW")
Tracked-On: OAM-111789
Signed-off-by: Jiaqing Zhao <jiaqing.zhao@intel.com>