### PR TITLE
Support boot from SPI

### DIFF
--- a/drivers/nvme/nvme.c
+++ b/drivers/nvme/nvme.c
@@ -49,7 +49,7 @@ static EFI_STATUS _init(storage_t *s)
 	pcidev_t pci_dev = 0;
 	size_t i,j;
 
-	pci_dev = get_diskbus();
+	pci_dev = get_media_diskbus(OsBootDeviceNvme);
 	DEBUG_NVME ((EFI_D_INFO, "pci dev = 0x%X\n", pci_dev));
 	if (pci_dev == 0){
 		for (i = 0; i < ARRAY_SIZE(SUPPORTED_DEVICES); i++)

--- a/include/libefiwrapper/storage.h
+++ b/include/libefiwrapper/storage.h
@@ -56,6 +56,7 @@ enum storage_type {
 	STORAGE_SATA,
 	STORAGE_NVME,
 	STORAGE_VIRTUAL,
+	STORAGE_USB,
 	STORAGE_ALL
 };
 
@@ -85,5 +86,6 @@ EFI_STATUS identify_boot_media();
 
 boot_dev_t* get_boot_media();
 UINT8 get_boot_media_device_path_type(void);
-uint32_t get_diskbus();
+uint32_t get_bootdev_diskbus();
+uint32_t get_media_diskbus(SBL_OS_BOOT_MEDIUM_TYPE media_type);
 #endif	/* _STORAGE_H_ */


### PR DESCRIPTION
Support ELK mode by boot fastoot image from SPI flash. Bootoptionlist will be passed by bootdevices parameter to OS when booting from SPI flash. In this case, we need NVME BDF info to initialize NVME storage.

Tracked-On: OAM-112165