### PR TITLE
Fix boot_dev->type check in virtual_media driver

### DIFF
--- a/drivers/virtual_media/virtual_media.c
+++ b/drivers/virtual_media/virtual_media.c
@@ -161,7 +161,8 @@ static EFI_STATUS storage_virtual_media_init(EFI_SYSTEM_TABLE *st)
 	if (!boot_dev)
 		return EFI_INVALID_PARAMETER;
 
-	boot_dev->type = STORAGE_VIRTUAL;
+	if (boot_dev->type != STORAGE_VIRTUAL)
+		return EFI_SUCCESS;
 
 	storage_virtual_media.pci_device = (boot_dev->diskbus >> 8) & 0xff;
 	storage_virtual_media.pci_function = boot_dev->diskbus & 0xff;


### PR DESCRIPTION
Currently boot_dev->type will be forced assigned to STORAGE_VIRTUAL when virtual_media driver is enabled, causing nvme boot fail. Fix it by replacing it with a simple check.

Tracked-On: OAM-113064