### PR TITLE
Extend serial number length to avoid conflicts

### DIFF
--- a/drivers/nvme/NvmExpressHci.c
+++ b/drivers/nvme/NvmExpressHci.c
@@ -803,7 +803,7 @@ NvmeControllerInit (
 	NVME_AQA                        Aqa;
 	NVME_ASQ                        Asq;
 	NVME_ACQ                        Acq;
-	UINT8                           Sn[9];
+	UINT8                           Sn[21];
 	UINT8                           Mn[41];
 	UINT32                          NvmeHCBase;
 
@@ -935,7 +935,7 @@ NvmeControllerInit (
 	// Dump NvmExpress Identify Controller Data
 	//
 	CopyMem (Sn, Private->ControllerData->Sn, sizeof (Private->ControllerData->Sn));
-	Sn[8] = 0;
+	Sn[20] = 0;
 	CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
 	Mn[40] = 0;
 	DEBUG_NVME ((EFI_D_INFO, " == NVME IDENTIFY CONTROLLER DATA ==\n"));


### PR DESCRIPTION
Previously the length of serial number is 8. And difference targets may have the same serial number. Extend the length to 20 in this commit.

Tracked-On: OAM-113488