### PR TITLE
Update MemoryFence definition logic

### DIFF
--- a/drivers/nvme/NvmExpress.c
+++ b/drivers/nvme/NvmExpress.c
@@ -253,18 +253,6 @@ DiscoverAllNamespaces (
   return EFI_SUCCESS;
 }
 
-VOID
-EFIAPI
-MemoryFence (
-  VOID
-  )
-{
-  // This is a little bit of overkill and it is more about the compiler that it is
-  // actually processor synchronization. This is like the _ReadWriteBarrier
-  // Microsoft specific intrinsic
-  __asm__ __volatile__ ("":::"memory");
-}
-
 #define PCI_BASE_ADDRESSREG_OFFSET     0x10
 #define PCI_COMMAND_OFFSET             0x04
 #define PCI_DEVICE_ID_OFFSET           0x02

--- a/drivers/nvme/NvmExpress.h
+++ b/drivers/nvme/NvmExpress.h
@@ -464,4 +464,19 @@ NvmeDumpStatus (
   IN NVME_CQ             *Cq
   );
 
+/**
+	Used to serialize load and store operations.
+
+	All loads and stores that proceed calls to this function are
+	guaranteed to be globally visible when this function returns.
+
+**/
+static inline VOID EFIAPI MemoryFence (VOID)
+{
+	// This is a little bit of overkill and it is more about the compiler
+	// that it is actually processor synchronization. This is like
+	// the _ReadWriteBarrier Microsoft specific intrinsic
+	__asm__ __volatile__ ("":::"memory");
+}
+
 #endif

--- a/drivers/nvme/NvmExpressHci.c
+++ b/drivers/nvme/NvmExpressHci.c
@@ -20,21 +20,6 @@
 #include "NvmExpress.h"
 
 /**
-  Used to serialize load and store operations.
-
-  All loads and stores that proceed calls to this function are guaranteed to be
-  globally visible when this function returns.
-
-**/
-static inline VOID EFIAPI MemoryFence (VOID)
-{
-	// This is a little bit of overkill and it is more about the compiler that it is
-	// actually processor synchronization. This is like the _ReadWriteBarrier
-	// Microsoft specific intrinsic
-	__asm__ __volatile__ ("":::"memory");
-}
-
-/**
   Read/Write specified NVM host controller mmio register.
 
   @param[in]      Address      Host controller mmio base address.

--- a/libefiwrapper/lib.c
+++ b/libefiwrapper/lib.c
@@ -131,3 +131,18 @@ EFI_STATUS crc32(const void *buf, size_t size, UINT32 *crc_p)
 
 	return EFI_SUCCESS;
 }
+
+/**
+	Used to serialize load and store operations.
+
+	All loads and stores that proceed calls to this function are
+	guaranteed to be globally visible when this function returns.
+
+**/
+VOID EFIAPI MemoryFence (VOID)
+{
+	// This is a little bit of overkill and it is more about the compiler
+	// that it is actually processor synchronization. This is like
+	// the _ReadWriteBarrier Microsoft specific intrinsic
+	__asm__ __volatile__ ("":::"memory");
+}

--- a/libefiwrapper/lib.h
+++ b/libefiwrapper/lib.h
@@ -42,5 +42,6 @@ CHAR16 *str16dup(const CHAR16 *str);
 CHAR16 *str2str16_p(const char *str);
 
 EFI_STATUS crc32(const void *buf, size_t size, UINT32 *crc_p);
+VOID EFIAPI MemoryFence (VOID);
 
 #endif	/* _LIB_H_ */


### PR DESCRIPTION
Both nvme and virtual_media driver invokes MemoryFence function,
implement inline function in corresponding header files as inline
function to avoid multi definition link issue.

Also provide MemoryFence symbol in libefiwrapper for kernelflinger
to link MemoryFence symbol which supposed to be implemented in EFI
componment.

Tracked-On: OAM-113553