### PR TITLE
Remove dead code in nvme driver which may cause system hang

### DIFF
--- a/drivers/nvme/NvmExpress.c
+++ b/drivers/nvme/NvmExpress.c
@@ -429,7 +429,6 @@ NvmeInitialize (
 
   Private->Buffer                    = (UINT8 *)aligned_buf;
   Private->Signature                 = NVME_CONTROLLER_PRIVATE_DATA_SIGNATURE;
-  Private->NvmeHCBase                = read32((void *)(NvmeHcPciBase + PCI_BASE_ADDRESSREG_OFFSET)) & 0xFFFFF000;
   Private->Passthru.Mode             = &Private->PassThruMode;
   Private->Passthru.PassThru         = (EFI_NVM_EXPRESS_PASS_THRU_PASSTHRU)NvmExpressPassThru;
   Private->Passthru.GetNextNamespace = NvmExpressGetNextNamespace;


### PR DESCRIPTION
NvmeHcPciBase is the data used to select PCI BDF and register offset in CF8 port in PCI scan. Use it to access MMIO region is a bug. In some cases, the buggy address falls into iGPU stolen memory and such read access will cause bus hang later.

Tracked-On: OAM-115757