### PR TITLE
Fix static scan issues

### DIFF
--- a/drivers/nvme/NvmExpress.c
+++ b/drivers/nvme/NvmExpress.c
@@ -208,6 +208,11 @@ Exit:
   if (NamespaceData != NULL) {
     FreeZero (NamespaceData);
   }
+
+  if (EFI_ERROR(Status) && (Device != NULL)) {
+    FreeZero (Device);
+  }
+
   return Status;
 }
 


### PR DESCRIPTION
If exit with efi error status, free Device pointer to avoid resource leaks.

Tracked-On: OAM-118493