### PR TITLE
Get USB cable connection state

### DIFF
--- a/drivers/dw3/UsbDeviceModeProtocol.h
+++ b/drivers/dw3/UsbDeviceModeProtocol.h
@@ -82,7 +82,8 @@ typedef
 EFI_STATUS
 (EFIAPI *EFI_USB_DEVICE_MODE_RUN) (
 	IN EFI_USB_DEVICE_MODE_PROTOCOL               *This,
-	IN UINT32                                     TimeoutMs
+	IN UINT32                                     TimeoutMs,
+	UINT32 *state
 	);
 
 ///

--- a/drivers/dw3/dw3.c
+++ b/drivers/dw3/dw3.c
@@ -967,6 +967,7 @@ _usb_unbind(__attribute__((__unused__)) EFI_USB_DEVICE_MODE_PROTOCOL *This)
 
 	return EFI_SUCCESS;
 }
+extern int usb_connect_state;
 
 static EFIAPI EFI_STATUS
 _usb_stop(__attribute__((__unused__)) EFI_USB_DEVICE_MODE_PROTOCOL *This)
@@ -977,10 +978,9 @@ _usb_stop(__attribute__((__unused__)) EFI_USB_DEVICE_MODE_PROTOCOL *This)
 
 static EFIAPI EFI_STATUS
 _usb_run(__attribute__((__unused__)) EFI_USB_DEVICE_MODE_PROTOCOL *This,
-	 UINT32 TimeoutMs)
+	 UINT32 TimeoutMs, UINT32 *state)
 {
 	EFI_STATUS Status = EFI_DEVICE_ERROR;
-
 	/* TODO: check initialized */
 
 	mXdciRun = TRUE;
@@ -993,6 +993,8 @@ _usb_run(__attribute__((__unused__)) EFI_USB_DEVICE_MODE_PROTOCOL *This,
 
 	        /* check for timeout */
 	        if (TimeoutMs == 0) {
+			if (state)
+				*state = usb_connect_state;
 	                return EFI_TIMEOUT;
 	        }
 	        udelay(50);


### PR DESCRIPTION
Device should boot to normal mode if no USB connection If there is no USB connection in bootloader fastboot mode, device should enter to normal mode after timeout.

Test Done:
Boot, flash, boot to normal mode after USB timeout

Tracked-On: OAM-123898