### PR TITLE
Fix static scan issue: memory leak in storage.c

### DIFF
--- a/libefiwrapper/storage.c
+++ b/libefiwrapper/storage.c
@@ -184,7 +184,7 @@ EFI_STATUS storage_init(EFI_SYSTEM_TABLE *st, storage_t *storage,
 			goto err;
 		}
 	}
-
+	free(media);
 	return EFI_SUCCESS;
 
 err:


### PR DESCRIPTION
Free the variable media before return success.

Tracked-On: OAM-126064